### PR TITLE
장세웅: 전력망 둘로 나누기(23.06.15)

### DIFF
--- a/week1/전력망 둘로 나누기/장세웅_전력망_둘로_나누기.java
+++ b/week1/전력망 둘로 나누기/장세웅_전력망_둘로_나누기.java
@@ -1,0 +1,73 @@
+import java.util.*;
+
+public class 전력망_둘로_나누기 {
+    static boolean[] visited;
+    static List<Integer>[] nodes;
+    public static void main(String[] args) {
+        Solution s = new Solution();
+        System.out.println(s.solution(9, new int[][]{{1,3},{2,3},{3,4},{4,5},{4,6},{4,7},{7,8},{7,9}}));
+    }
+
+    static class Solution {
+        /**
+         * 전선을 끊어서 송전탑 갯수가 가능한 비슷하도록
+         * 두 전력망이 갖고 있는 송전탑 갯수의 차이를 반환
+         */
+        public int solution(int n, int[][] wires) {
+            // 인접리스트 생성
+            nodes = new ArrayList[n+1];
+            for(int i = 1; i < n+1; i++) {
+                nodes[i] = new ArrayList<>();
+            }
+
+            for(int i = 0; i < wires.length; i++) {
+                int node1 = wires[i][0];
+                int node2 = wires[i][1];
+
+                // 양방향
+                nodes[node1].add(node2);
+                nodes[node2].add(node1);
+            }
+
+            int min = Integer.MAX_VALUE;
+            for(int i = 0; i < wires.length; i++) {
+                int node1 = wires[i][0];
+                int node2 = wires[i][1];
+
+                // 양방향이라서 bfs를 2번 적용함
+                // node1이 시작점이고, node1과 node2가 끊어졌을 때
+                int bfs1 = bfs(n, node1, node2);
+                // node2이 시작점이고, node1과 node2가 끊어졌을 때
+                int bfs2 = bfs(n, node2, node1);
+
+                // bfs1, bfs2의 차이가 가장 작은것이 정답
+                min = Math.min(min, Math.abs(bfs1 - bfs2));
+            }
+
+            return min;
+        }
+
+        private int bfs(int n, int node1, int node2) {
+            Queue<Integer> queue = new ArrayDeque<>();
+            queue.offer(node1);
+            visited = new boolean[n+1];
+            visited[node1] = true;
+            int count = 0;
+
+            while (!queue.isEmpty()) {
+                Integer poll = queue.poll();
+
+                for(Integer i : nodes[poll]) {
+                    // 인접 노드가 끊어졌을 때
+                    if(i != node2 && !visited[i]) {
+                        visited[i] = true;
+                        queue.offer(i);
+                        count++;
+                    }
+                }
+            }
+
+            return count;
+        }
+    }
+}


### PR DESCRIPTION
## 요약
* 풀이한 문제: #13 
* 풀이 상태: 완료
* 체감 난이도: 보통

## 새롭게 알게된 부분
처음에 엣지리스트를 생성하여 해결하려고 했으나, 구현이 어려워 인접리스트를 활용하여 해결했습니다.

## 공부해야할 부분
엣지리스트와 연결리스트 활용

## 문제 풀이 방향

 > bfs를 이용하여 문제를 해결하였습니다.

1. 노드를 기준으로 인접리스트를 생성합니다.
2. 방향이 없기 때문에 양방향으로 관계를 설정합니다.
3. node1과 node2를 파라미터로 받습니다.
4.  node1부터 탐색을 시작하여 다음 탐색노드가 node2와 같지 않은 경우
     (전력망이 끊어진 경우)에만 다음 노드로 탐색을 합니다.

## 참고 
-->