### PR TITLE
김유정: 표현 가능한 이진트리 문제풀이(23.07.03)

### DIFF
--- a/week4/표현_가능한_이진트리/김유정_표현_가능한_이진트리.java
+++ b/week4/표현_가능한_이진트리/김유정_표현_가능한_이진트리.java
@@ -1,0 +1,50 @@
+package week4.표현_가능한_이진트리;
+
+import java.util.*;
+import java.util.stream.IntStream;
+
+public class 김유정_표현_가능한_이진트리 {
+    public static void main(String[] args) {
+        System.out.println(new 김유정_표현_가능한_이진트리_Solution().solution(new long[]{7, 42, 5}));
+    }
+}
+
+class 김유정_표현_가능한_이진트리_Solution {
+    final int AVAILABLE = 1;
+    
+    public int[] solution(long[] numbers) {
+        int[] answer = new int[numbers.length];
+        for (int i = 0; i < numbers.length; i++) {
+            if (isAvailable(toBinaryStr(numbers[i]))) {
+                answer[i] = AVAILABLE;
+            }
+        }
+        return answer;
+    }
+    
+    private String toBinaryStr(long number) {
+        // 0001010
+        String binaryStr = Long.toBinaryString(number);
+        int i = 1;
+        while (binaryStr.length() > Math.pow(2, i) - 1) {
+            i++;
+        }
+        return "0".repeat((int) Math.pow(2, i) - 1 - binaryStr.length()) + binaryStr;
+    }
+    
+    private boolean isAvailable(String binaryStr) {
+        // 홀스 인덱스는 부모 노드 -> 1
+        // 양쪽 자식 노드가 모두 0이면 안됨
+        int[] binaryNumArr = IntStream.range(0, binaryStr.length())
+                                    .map(i -> binaryStr.charAt(i) - '0')
+                                    .toArray();
+        System.out.println(Arrays.toString(binaryNumArr));
+        for (int i = 1; i < binaryStr.length(); i += 2) {
+            if (binaryNumArr[i - 1] + binaryNumArr[i + 1] > 0 && binaryNumArr[i] == 0) {
+                System.out.printf("i = %d, binaryNumArr[i] = %d\n", i, binaryNumArr[i]);
+                return false;
+            }
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
## 요약
* 풀이한 문제: #53 
* 풀이 상태: 진행중(제출시 정확성: 45%)
* 체감 난이도: 어려움

## 새롭게 알게된 부분
* 10진수 → 2진수: `Integer.toBinaryString(10진수)` → return String;
* 10진수 → 8진수: `Integer.toOctalString(10진수)` → return String;
* 10진수 → 16진수: Integer.toHexString(16진수) → return String;
* 2진수, 8진수, 16진수 → 2진수: Integer.parseInt(String s, 진수) → return int;
Long도 동일

## 문제 풀이 방향
* 이진수로 변환한 문자열에서 홀수 인덱스만 부모 노드가 될 가능성이 있음
* 홀수 인덱스를 반복하면서 양쪽에 자식 노드가 존재한다면 부모노드가 반드시 1이어야함. 이 조건을 틀릴 경우 false 반환.